### PR TITLE
Shared weights and sparse-but-random inits

### DIFF
--- a/config/003.gin
+++ b/config/003.gin
@@ -1,0 +1,16 @@
+# WAE with shared weights
+
+build_model.Model = @WAE
+build_model.n_layers = 1
+build_model.eps = 0.01
+build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
+
+WAE.use_biases = False
+WAE.normalize_inputs = False
+WAE.shared_weights = True
+WAE.keep_prob = 0.5
+WAE.lam = 0.0
+WAE.lr = 3e-4
+
+train.batch_size = 100
+train.n_epochs = 10

--- a/config/004.gin
+++ b/config/004.gin
@@ -1,0 +1,16 @@
+# WAE with shared weights
+
+build_model.Model = @WAE
+build_model.n_layers = 1
+build_model.eps = 0.01
+build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
+
+WAE.use_biases = True
+WAE.normalize_inputs = False
+WAE.shared_weights = True
+WAE.keep_prob = 1.0
+WAE.lam = 0.001
+WAE.lr = 3e-4
+
+train.batch_size = 100
+train.n_epochs = 10

--- a/config/004.gin
+++ b/config/004.gin
@@ -2,14 +2,13 @@
 
 build_model.Model = @WAE
 build_model.n_layers = 1
-build_model.eps = 0.01
 build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
 
 WAE.use_biases = False
 WAE.normalize_inputs = False
 WAE.shared_weights = True
 WAE.keep_prob = 1.0
-WAE.lam = 0.001
+WAE.lam = 1e-6
 WAE.lr = 3e-4
 
 train.batch_size = 100

--- a/config/005.gin
+++ b/config/005.gin
@@ -2,14 +2,13 @@
 
 build_model.Model = @WAE
 build_model.n_layers = 2
-build_model.eps = 0.01
 build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
 
 WAE.use_biases = False
 WAE.normalize_inputs = False
 WAE.shared_weights = True
 WAE.keep_prob = 1.0
-WAE.lam = 0.001
+WAE.lam = 1e-6
 WAE.lr = 3e-4
 
 train.batch_size = 100

--- a/config/005.gin
+++ b/config/005.gin
@@ -8,7 +8,7 @@ WAE.use_biases = False
 WAE.normalize_inputs = False
 WAE.shared_weights = True
 WAE.keep_prob = 1.0
-WAE.lam = 1e-6
+WAE.lam = 0.0
 WAE.lr = 3e-4
 
 train.batch_size = 100

--- a/config/005.gin
+++ b/config/005.gin
@@ -1,7 +1,7 @@
-# WAE with "shared weights" (except that n_layers == 1)
+# WAE with actual shared weights: 2 layers
 
 build_model.Model = @WAE
-build_model.n_layers = 1
+build_model.n_layers = 2
 build_model.eps = 0.01
 build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
 

--- a/config/006.gin
+++ b/config/006.gin
@@ -1,0 +1,15 @@
+# WAE with actual shared weights: 2 layers
+
+build_model.Model = @WAE
+build_model.n_layers = 3
+build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
+
+WAE.use_biases = False
+WAE.normalize_inputs = False
+WAE.shared_weights = True
+WAE.keep_prob = 1.0
+WAE.lam = 0.0
+WAE.lr = 3e-4
+
+train.batch_size = 100
+train.n_epochs = 10

--- a/config/007.gin
+++ b/config/007.gin
@@ -1,6 +1,6 @@
-# WAE with actual shared weights: 3 layers
+# MultiWAE with actual shared weights: 3 layers
 
-build_model.Model = @WAE
+build_model.Model = @MultiWAE
 build_model.n_layers = 3
 build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
 

--- a/config/008.gin
+++ b/config/008.gin
@@ -1,0 +1,16 @@
+# MultiWAE with 3 shared-weight layers, bias and dropout
+
+build_model.Model = @MultiWAE
+build_model.n_layers = 3
+build_model.noise = 0.5
+build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
+
+WAE.use_biases = True
+WAE.normalize_inputs = False
+WAE.shared_weights = True
+WAE.keep_prob = 0.8
+WAE.lam = 3e-4
+WAE.lr = 3e-4
+
+train.batch_size = 50
+train.n_epochs = 15

--- a/config/009.gin
+++ b/config/009.gin
@@ -1,0 +1,17 @@
+# MultiWAE with 3 shared-weight layers, bias and dropout
+
+build_model.Model = @MultiWAE
+build_model.n_layers = 1
+build_model.slim_path = '/home/jvanbalen/experiments/wae/pruned_slim.npz'
+
+sparse_tensor_from_init.randomize=True
+
+WAE.use_biases = True
+WAE.normalize_inputs = False
+WAE.shared_weights = True
+WAE.keep_prob = 0.8
+WAE.lam = 1e-3
+WAE.lr = 3e-4
+
+train.batch_size = 100
+train.n_epochs = 10

--- a/config/009.gin
+++ b/config/009.gin
@@ -1,4 +1,4 @@
-# MultiWAE with 3 shared-weight layers, bias and dropout
+# MultiWAE with 1 layer, bias and dropout
 
 build_model.Model = @MultiWAE
 build_model.n_layers = 1

--- a/models/tf.py
+++ b/models/tf.py
@@ -230,25 +230,26 @@ def train(model, x_train, x_val, y_val, batch_size=100, n_epochs=10, log_dir=Non
 
     TODO: model snapshots (check lines containing "best_ndcg" in Liang's notebook)
     """
+
     with tf.Session() as sess:
         metric_logger = MetricLogger(log_dir, sess) if log_dir is not None else None
 
         init = tf.global_variables_initializer()
         sess.run(init)
 
-        ndcg = evaluate(model, sess, x_val, y_val, metric_logger=metric_logger)
-        print('Validation NDCG = {}'.format(ndcg))
+        metrics = evaluate(model, sess, x_val, y_val, metric_logger=metric_logger)
+        print('Validation NDCG = {}'.format(metrics))
 
         for epoch in range(n_epochs):
             print('Training. Epoch = {}/{}'.format(epoch + 1, n_epochs))
             train_one_epoch(model, sess, x_train, batch_size=batch_size,
                             metric_logger=metric_logger)
 
-            ndcg = evaluate(model, sess, x_val, y_val, batch_size=batch_size,
-                            metric_logger=metric_logger)
-            print('Validation NDCG = {}'.format(ndcg))
+            metrics = evaluate(model, sess, x_val, y_val, batch_size=batch_size,
+                               metric_logger=metric_logger)
+            print('Validation NDCG = {}'.format(metrics))
 
-    return ndcg
+    return metrics
 
 
 @gin.configurable

--- a/models/tf.py
+++ b/models/tf.py
@@ -52,13 +52,12 @@ class MultiWAE(object):
             weight_key = "weight_{}to{}".format(i, i+1)
             bias_key = "bias_{}".format(i+1)
 
-            if self.shared_weights and i > 0:
-                weights = self.weights[-1]
-            else:
+            if not self.shared_weights or i == 0:
                 init = init.tocoo()
                 weight_inds = tf.convert_to_tensor(list(zip(init.row, init.col)), dtype=np.int64)
                 weight_data = tf.Variable(init.data.astype(np.float32), name=weight_key)
-                weight = tf.SparseTensor(weight_inds, tf.identity(weight_data), dense_shape=init.shape)
+                weight = tf.SparseTensor(weight_inds, tf.identity(weight_data),
+                                         dense_shape=init.shape)
                 weight = tf.sparse.reorder(weight)  # seems to be suggested here:
                 # https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor?version=stable
             self.weights.append(weight)

--- a/models/tf.py
+++ b/models/tf.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 from scipy.sparse import issparse
 from tensorflow.contrib.layers import apply_regularization, l2_regularizer
 
-from metric import ndcg_binary_at_k_batch
+from metric import ndcg_binary_at_k_batch, recall_at_k_batch
 
 
 @gin.configurable
@@ -168,6 +168,7 @@ def evaluate(model, sess, x_val, y_val, batch_size=100, metric_logger=None):
 
     loss_list = []
     ndcg_list = []
+    r100_list = []
     for i_batch, start in enumerate(range(0, n_val, batch_size)):
         print('validation batch {}/{}...'.format(i_batch + 1, int(n_val / batch_size)))
 
@@ -182,17 +183,19 @@ def evaluate(model, sess, x_val, y_val, batch_size=100, metric_logger=None):
         y_pred, ae_loss = sess.run([model.logits, model.loss], feed_dict={model.input_ph: x})
         # exclude examples from training and validation (if any)
         y_pred[x.nonzero()] = -np.inf
-        ndcg_list.append(ndcg_binary_at_k_batch(y_pred, y))
+        ndcg_list.append(ndcg_binary_at_k_batch(y_pred, y, k=100))
+        r100_list.append(recall_at_k_batch(y_pred, y, k=100))
         loss_list.append(ae_loss)
 
     val_ndcg = np.concatenate(ndcg_list).mean()  # mean over n_val
+    val_r100 = np.concatenate(r100_list).mean()  # mean over n_val
     val_loss = np.mean(loss_list)  # mean over batches
+    metrics = {'val_ndcg': val_ndcg, 'val_r100': val_r100, 'val_loss': val_loss}
 
     if metric_logger is not None:
-        metrics = {'val_ndcg': val_ndcg, 'val_loss': val_loss}
         metric_logger.log_metrics(metrics)
 
-    return val_ndcg, val_loss
+    return metrics
 
 
 def train_one_epoch(model, sess, x_train,

--- a/models/tf.py
+++ b/models/tf.py
@@ -246,6 +246,6 @@ def sparse_tensor_from_init(init, weight_key='sparse_weight'):
     # https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor?version=stable
 
     #  summary for tensorboard
-    tf.summary.histogram(weight_key, w.data)
+    tf.summary.histogram(weight_key, w_data)
 
     return w

--- a/models/tf.py
+++ b/models/tf.py
@@ -251,11 +251,16 @@ def train(model, x_train, x_val, y_val, batch_size=100, n_epochs=10, log_dir=Non
     return ndcg
 
 
-def sparse_tensor_from_init(init, weight_key='sparse_weight'):
+@gin.configurable
+def sparse_tensor_from_init(init, weight_key='sparse_weight', randomize=False, eps=0.001):
 
     init = init.tocoo()
+    init_data = init.data
+    if randomize:
+        init_data = eps * np.random.randn(*init.data.shape)
+
     w_inds = tf.convert_to_tensor(list(zip(init.row, init.col)), dtype=np.int64)
-    w_data = tf.Variable(init.data.astype(np.float32), name=weight_key)
+    w_data = tf.Variable(init_data.astype(np.float32), name=weight_key)
     w = tf.SparseTensor(w_inds, tf.identity(w_data),
                         dense_shape=init.shape)
     w = tf.sparse.reorder(w)  # as suggested here:

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -1,6 +1,6 @@
 """
 Ex.:
-python wae.py --data ~/data/ml-20m/ --log-dir ~/experiments/wae/logs/WAE/ \
+python wae.py --data ~/data/ml-20m/ --logdir ~/experiments/wae/logs/WAE/ \
     --config config/001.gin
 """
 import gin
@@ -42,7 +42,8 @@ if __name__ == '__main__':
 
     parser = ArgumentParser()
     parser.add_argument('--data', help='directory containing pre-processed dataset', type=str)
-    parser.add_argument('--log-dir', help='log directory for tensorboard', type=str)
+    parser.add_argument('--cap', help='cap train/val data for debugging', type=int, default=None)
+    parser.add_argument('--logdir', help='log directory for tensorboard', type=str)
     parser.add_argument('--config', help='path to gin config file', type=str)
     args = parser.parse_args()
 
@@ -55,7 +56,10 @@ if __name__ == '__main__':
     x_val, y_val = loader.load_data('validation')
 
     print('Constructing model...')
-    model = build_model(x_train)
+    model = build_model(x_train)  # don't cap yet, we want realistic sparsities
 
     print('Training...')
-    train(model, x_train, x_val, y_val, log_dir=args.log_dir)
+    if args.cap:
+        x_train = x_train[:args.cap]
+        x_val, y_val = x_val[:args.cap], y_val[:args.cap]
+    train(model, x_train, x_val, y_val, log_dir=args.logdir)

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -4,10 +4,9 @@ python wae.py --data ~/data/ml-20m/ --logdir ~/experiments/wae/logs/WAE/ \
     --config config/001.gin
 """
 import gin
-import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
-from scipy.sparse import csr_matrix, load_npz
+from scipy.sparse import load_npz
 
 from data import DataLoader
 from util import prune_global
@@ -17,13 +16,12 @@ from models.slim import closed_form_slim
 
 
 @gin.configurable
-def build_model(x_train, Model=WAE, n_layers=3, noise=0.0, eps=0.01, slim_path=None):
+def build_model(x_train, Model=WAE, n_layers=3, randomize=False, eps=0.01, slim_path=None):
     """Build a wide auto-encoder model with initial weights based on the SLIM
     item-item matrix.
     First weight will be the sparse SLIM weights with some noise,
     the others will be the same weights again, scaled by `eps`.
     """
-
     if slim_path is not None:
         print('Reading pre-computed SLIM matrix from {}...'.format(slim_path))
         pruned_slim = load_npz(slim_path)
@@ -32,15 +30,8 @@ def build_model(x_train, Model=WAE, n_layers=3, noise=0.0, eps=0.01, slim_path=N
         slim = closed_form_slim(x_train, l2_reg=500)
         pruned_slim = prune_global(slim)
 
-    eye = csr_matrix(np.eye(pruned_slim.shape[0]))
-    r = 1.0 - noise / 2 + np.random.rand(*pruned_slim.data.shape) * noise
-    pruned_slim.data = r * pruned_slim.data
-    init_W1 = [pruned_slim]
-    other_inits = [eye + eps * pruned_slim for _ in range(n_layers - 1)]
-    # other_inits will not be used if shared_weights = True
-
     tf.reset_default_graph()
-    model = Model(init_W1 + other_inits)
+    model = Model([pruned_slim] * n_layers)
 
     return model
 

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -33,7 +33,7 @@ def build_model(x_train, Model=WAE, n_layers=3, noise=0.0, eps=0.01, slim_path=N
         pruned_slim = prune_global(slim)
 
     eye = csr_matrix(np.eye(pruned_slim.shape[0]))
-    r = 1.0 + np.random.rand(*pruned_slim.shape) * noise
+    r = 1.0 - noise / 2 + np.random.rand(*pruned_slim.data.shape) * noise
     pruned_slim.data = r * pruned_slim.data
     init_W1 = [pruned_slim]
     other_inits = [eye + eps * pruned_slim for _ in range(n_layers - 1)]

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -1,6 +1,6 @@
 """
 Ex.:
-python experiment.py --data ~/data/ml-20m/ --log-dir ~/experiments/wae/logs/WAE/ \
+python wae.py --data ~/data/ml-20m/ --log-dir ~/experiments/wae/logs/WAE/ \
     --config config/001.gin
 """
 import gin

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -28,8 +28,9 @@ def build_model(x_train, Model=WAE, n_layers=3, eps=0.01, slim_path=None):
         pruned_slim = prune_global(slim)
 
     eye = csr_matrix(np.eye(pruned_slim.shape[0]))
-    encoder_inits = [eye + eps * pruned_slim for _ in range(n_layers - 1)]
-    inits = encoder_inits + [pruned_slim]
+    other_inits = [eye + eps * pruned_slim for _ in range(n_layers - 1)]
+    inits = [pruned_slim] + other_inits
+    # other_inits will not be used if shared_weights = True
 
     tf.reset_default_graph()
     model = Model(inits)

--- a/scripts/wae.py
+++ b/scripts/wae.py
@@ -34,7 +34,8 @@ def build_model(x_train, Model=WAE, n_layers=3, noise=0.0, eps=0.01, slim_path=N
 
     eye = csr_matrix(np.eye(pruned_slim.shape[0]))
     r = 1.0 + np.random.rand(*pruned_slim.shape) * noise
-    init_W1 = [r * pruned_slim]
+    pruned_slim.data = r * pruned_slim.data
+    init_W1 = [pruned_slim]
     other_inits = [eye + eps * pruned_slim for _ in range(n_layers - 1)]
     # other_inits will not be used if shared_weights = True
 


### PR DESCRIPTION
Support:
- sharing weights across layers
  to prevent the model from learning W2 = W1^{-1}
- initializing weights with given sparsity value but random values
  to (try and) prevent getting stuck in local minimum when initialization with pretrained weights